### PR TITLE
Fix docker login for open-iscsi push

### DIFF
--- a/playbooks/pre-open-iscsi.yml
+++ b/playbooks/pre-open-iscsi.yml
@@ -4,3 +4,11 @@
 
   roles:
     - ensure-docker
+
+  tasks:
+    - name: Install required packages
+      become: true
+      ansible.builtin.apt:
+        update_cache: yes
+        pkg:
+          - python3-requests


### PR DESCRIPTION
Docker login requires python requests library, which is not installed by default.